### PR TITLE
Avoid user prompting when automatically restoring the environment with `renv`

### DIFF
--- a/src/Build_project.R
+++ b/src/Build_project.R
@@ -18,7 +18,7 @@ rm(list = ls())
 
 # First re-install locally all the project environment:
 #  Must use R v4.1.3!!
-renv::restore()
+renv::restore(prompt = FALSE)
 
 ## ---- INCLUDES: --------------------------------------------------------------
 


### PR DESCRIPTION
User prompting for installing the packages by `renv` interrupted the automatic building of the project